### PR TITLE
Fix the Docker Image Push Step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,9 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
         uses: docker/build-push-action@v6
         with:
-          push: true
+          context: .
+          file: Dockerfile.template
+          build-args: |
+            DOXYGEN_VERSION=${{ matrix.version }}
           tags: ${{ vars.DOCKER_USERNAME }}/doxygen:${{ matrix.version }}
+          push: true


### PR DESCRIPTION
In #1, we introduce the GitHub Action CI flow. The Docker build step is verified; however, the push step is challenging to verify because it only triggers when pushing to the main branch. It turned out that there was an issue – the docker/build-push-action was not configured correctly. This PR fixes the configuration of the final push step.