### PR TITLE
Add the Login Step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
         run: |
           docker run --rm ${{ vars.DOCKER_USERNAME }}/doxygen:${{ matrix.version }} doxygen --version
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Push Docker image
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Somehow the CI Docker login step is missing, causing push step to fail. This PR fix the issue.