### PR TITLE
Update Git Version in the Docker Image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           docker run --rm ${{ vars.DOCKER_USERNAME }}/doxygen:${{ matrix.version }} doxygen --version
 
       - name: Login to Docker Hub
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKER_USERNAME }}

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -3,6 +3,7 @@ FROM ubuntu:22.04
 ARG DOXYGEN_VERSION
 RUN apt-get update && apt-get install -y \
     wget \
+    git \
     graphviz \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The git version in the `ubuntu:22.04` image is too old, and is not compatible with the GitHub official `actions/checkout@v4`. Update the git version to latest in this Docker image.